### PR TITLE
Combined dependencies PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10121,9 +10121,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -10374,9 +10374,9 @@
       },
       "dependencies": {
         "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
           "dev": true
         }
       }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump qs from 6.5.2 to 6.5.3 (#26) @dependabot
* Bump decode-uri-component from 0.2.0 to 0.2.2 (#25) @dependabot
* Bump loader-utils from 1.4.0 to 1.4.2 (#24) @dependabot
* Bump terser from 5.7.0 to 5.14.2 (#23) @dependabot
* Bump async from 2.6.3 to 2.6.4 (#22) @dependabot
* Bump minimist from 1.2.5 to 1.2.6 (#21) @dependabot
* Bump follow-redirects from 1.14.1 to 1.14.8 (#20) @dependabot
* Bump nanoid from 3.1.23 to 3.2.0 (#19) @dependabot
* Bump path-parse from 1.0.6 to 1.0.7 (#17) @dependabot
* Bump ws from 6.2.1 to 6.2.2 (#16) @dependabot
